### PR TITLE
Fix documents for Loader arguments

### DIFF
--- a/xslate.go
+++ b/xslate.go
@@ -26,7 +26,7 @@ The simplest way to use Xslate is to prepare a directory with Xslate templates
 
   tx, _ := xslate.New(xslate.Args {
     "Loader": xslate.Args {
-      Paths: []string { "/path/to/templates" },
+      "LoadPaths": []string { "/path/to/templates" },
     },
   })
   output, _ := tx.Render("main.tx", xslate.Vars { ... })


### PR DESCRIPTION
godoc in xslate.go says

```
  tx, _ := xslate.New(xslate.Args {
    "Loader": xslate.Args {
      Paths: []string { "/path/to/templates" },
    },
  })
```

but "LoadPaths" is correct name to specify template path.
